### PR TITLE
Fix possible NREs in OnEnumerationComplete

### DIFF
--- a/src/AsyncEnumerator.cs
+++ b/src/AsyncEnumerator.cs
@@ -165,11 +165,11 @@ namespace System.Collections.Async
             }
             else if (task.IsCanceled)
             {
-                enumerator._yield.SetCanceled();
+                enumerator._yield?.SetCanceled();
             }
             else
             {
-                enumerator._yield.SetComplete();
+                enumerator._yield?.SetComplete();
             }
         }
     }


### PR DESCRIPTION
If enumeration is cancelled, enumerator._yield may be null.  Use the safe navigation operator to ensure that we don't throw an NRE in those cases.